### PR TITLE
Disable stepper motor deactivation timeout for M600/M601 or filament runout

### DIFF
--- a/TFT/src/User/API/extend.c
+++ b/TFT/src/User/API/extend.c
@@ -145,7 +145,7 @@ void loopFrontEndFILRunoutDetect(void)
 {
   if (!getPrintRunout()) return;
 
-  if (setPrintPause(true,false, false))
+  if (setPrintPause(true,false, true))
   {
     setPrintRunout(false);
     popupReminder(textSelect(LABEL_WARNING), textSelect(LABEL_FILAMENT_RUNOUT));

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -532,7 +532,17 @@ void sendQueueCmd(void)
             break;
           case 18: //M18/M84 disable steppers
           case 84:
-            coordinateSetKnown(false);
+            if(cmd_seen('S') && !cmd_seen('Y') && !cmd_seen('Z') && !cmd_seen('E'))
+            {
+              // Do not mark coordinate as unknown in this case as this is a M18/M84 S<timeout>
+              // command that doesn't disable the motors right away but will set their idling
+              // timeout.
+            }
+            else
+            {
+              // This is something else than an "M18/M84 S<timeout>", this will disable at least one stepper, set coordinate as unknown
+              coordinateSetKnown(false);
+            }
             break;
 
           case 27: //M27

--- a/TFT/src/User/Menu/BabyStep.c
+++ b/TFT/src/User/Menu/BabyStep.c
@@ -7,10 +7,10 @@ MENUITEMS babyStepItems = {
   LABEL_BABYSTEP,
 //icon                        label
  {
-  {ICON_INC,                  LABEL_INC},
+  {ICON_Z_INC,                  LABEL_Z_INC},
   {ICON_BACKGROUND,           LABEL_BACKGROUND},
   {ICON_BACKGROUND,           LABEL_BACKGROUND},
-  {ICON_DEC,                  LABEL_DEC},
+  {ICON_Z_DEC,                  LABEL_Z_DEC},
   {ICON_BACKGROUND,           LABEL_BACKGROUND},
   {ICON_001_MM,                LABEL_001_MM},
   {ICON_RESET_VALUE,          LABEL_RESET},

--- a/TFT/src/User/Menu/Printing.c
+++ b/TFT/src/User/Menu/Printing.c
@@ -375,7 +375,12 @@ bool setPrintPause(bool is_pause, bool is_m0pause, bool M600)
   }
   resumeToPause(is_pause);
   pauseLock = false;
-  if(M600){
+
+  if (M600 && is_pause)
+  {
+      // Disable stepper_motors_timeout.
+      // Otherwise bed or printhead risk to be moved when inserting filament, causing layer shifting when resuming print.
+      mustStoreCmd("M84 S0\n");
       Buzzer_play(sound_notify);
       popupReminder((u8 *)"M600/M601", textSelect(LABEL_FILAMENT_CHANGE));
   }


### PR DESCRIPTION
On Marlin FW, there's a feature to handle stepper motors idling, if they have been inactive for a specified period of time (usually 120 seconds, see DEFAULT_STEPPER_DEACTIVE_TIME in Marlin's Configuration_adv.h file), they are turned off.

This can be problematic when a print is paused, because at filament insertion time, bed or print head can be moved. Even the slightest move will result in layer shifting when the print is resumed.

To prevent this, Marlin implemented the ADVANCED_PAUSE_FEATURE with PAUSE_PARK_NO_STEPPER_TIMEOUT.

When a M600 is detected, it disable the stepper timeout during filament change.

But since this TFT FW override M600 command, all this logic never happens on Marlin's side, so the motors are getting timeouts and are disabled.

Same goes for the filament sensor, a paused is triggered by the TFT, but the motors are timeouting.

To prevent this, when a M600 is detected, we need to send a "M84 S0" command which disable the timeout.

Ideally it would be best to set back the initial value when resuming the print, but I didn't find a way to get the initial value.